### PR TITLE
Serialize deploys with a concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,13 @@ name: SFTP Upload
 # Is a special event that allows you to manually trigger the workflow, e.g. by clicking the “Run workflow” button on the Actions tab in your GitHub repository.
 on:
   workflow_dispatch:
+
+# Shares the group with direct.yml so a manual upload cannot run at the same
+# time as a push-triggered deploy — both write to the same SFTP target.
+concurrency:
+  group: sftp-deploy
+  cancel-in-progress: false
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -4,6 +4,20 @@ on:
   push:
     branches:
       - main  # Trigger this workflow on pushes to the 'main' branch
+
+# Serialize every deploy to the live host. Two merges in quick succession
+# otherwise race: sftp_upload_direct.sh runs `mirror -R` without --delete, so
+# whichever run finishes last decides which build the deployed HTML points at,
+# and a slower older run can silently revert the site while leaving both
+# _next/static/<buildId>/ trees in place. The group is shared with deploy.yml,
+# which writes to the same SFTP target.
+#
+# cancel-in-progress is false so an upload in flight is never killed part-way,
+# which would leave the host with a half-mirrored tree.
+concurrency:
+  group: sftp-deploy
+  cancel-in-progress: false
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Source for **https://www.kuegeler.com** — the personal site of Michael Kügele
 │   ├── ci.yml                pull_request → build check (no deploy)
 │   ├── direct.yml            push to main → SFTP mirror of blog `out/` (active deploy)
 │   └── deploy.yml            manual (workflow_dispatch) zip-based upload
+│                             both share concurrency group `sftp-deploy`
 ├── sftp_upload_direct.sh     lftp mirror, used by direct.yml
 ├── sftp_upload.sh            lftp zip upload, used by deploy.yml
 ├── index.html, cv.html, datenschutz.html, style.css, werk/   legacy site
@@ -129,6 +130,8 @@ It deliberately does **not** verify that the committed `out/` matches the source
 ## Deployment
 
 - **`.github/workflows/direct.yml`** — the live path. Triggers on push to `main`. Checks out the repo and runs `sftp_upload_direct.sh`, which `lftp mirror -R`s the contents of `./michael-kuegeler-blog/out` into the host directory. No build step in CI.
+- **`mirror -R` runs without `--delete`.** Files are uploaded and overwritten but never removed, so anything deleted from `out/` lingers on the host indefinitely — including the `_next/static/<buildId>/` directories of every previous build. Harmless in itself (stale assets are simply unreferenced), but it has a sharp edge: since the HTML is what points at a build ID, whichever deploy finishes **last** decides which build the site actually serves.
+- **Both deploy workflows share `concurrency: group: sftp-deploy`** with `cancel-in-progress: false`, which exists because of exactly that edge. Two merges in quick succession used to race, and a slower older run could finish after a newer one and silently revert the site to the previous build. The group serializes them in start order; `cancel-in-progress` stays false so an upload in flight is never killed mid-mirror, which would leave the host half-updated. Do not remove this, and keep the group name identical in both files — a manual `deploy.yml` run and a push-triggered `direct.yml` run write to the same target.
 - **`.github/workflows/deploy.yml`** — manual `workflow_dispatch` only. Zips `out/` and `put`s it via `sftp_upload.sh`; remote unzip is commented out, so this is effectively a fallback/upload-only path.
 - Secrets used by both: `SFTP_SERVER`, `SFTP_USERNAME`, `SFTP_PASSWORD`, `SFTP_TARGET`. Never echo or commit these.
 - `michael-kuegeler-blog/.github/workflows/pages.yml` is leftover from the upstream template. It sits in a subdirectory, so GitHub Actions does not run it — ignore it.


### PR DESCRIPTION
Two merges in quick succession race against the same SFTP target. This adds a shared `concurrency` group to both deploy workflows so they run one at a time.

## The failure mode

`sftp_upload_direct.sh` runs `mirror -R` **without** `--delete`, so files are uploaded and overwritten but never removed. The HTML is what points at a given build, so whichever deploy finishes *last* decides which build the site actually serves — not whichever merged last.

A slower older run finishing after a newer one therefore silently reverts the live site to the previous build, while leaving both `_next/static/<buildId>/` trees on the host. Nothing breaks visibly, which is what makes it easy to miss.

This is not hypothetical. Merging #22 and #23 in quick succession produced exactly this overlap:

| Run | Build | Finished |
|---|---|---|
| #25 (`72fc308`) | old `jFZt1p7hz5BaI-6GsUCNF` | 07:51:59 |
| #26 (`a6291fa`) | new `C9zEzPEQTNk6LqkKlbfLi` | 07:56:17 — last |

Both succeeded and the newer build happened to land last, so the site is fine. Reversed, the site would now be serving the previous build despite the newer merge.

## The fix

Both workflows get:

```yaml
concurrency:
  group: sftp-deploy
  cancel-in-progress: false
```

Two choices worth recording:

- **The group is shared rather than per-workflow.** `deploy.yml` and `direct.yml` write to the same target, so a manual upload can race a push-triggered one. Per-workflow groups would fix only half the problem, which is why `CLAUDE.md` notes the group name must stay identical in both files.
- **`cancel-in-progress` is false.** Cancelling would be worse than racing here: killing `lftp` part-way through a mirror leaves the host with a half-updated tree. Queueing guarantees each deploy completes.

## Note

Merging this triggers another deploy, which is a no-op re-upload — `out/` is unchanged since the last one.

`CLAUDE.md` gains the `mirror -R`-without-`--delete` behaviour and the reasoning above, since neither is discoverable from the workflow files alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3Menqxa2JYdkEd6oZwPUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3Menqxa2JYdkEd6oZwPUr)_