### PR TITLE
Update legacy datenschutz.html to match the new privacy policy

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
-<title>kuegeler.com</title>
+<title>Datenschutz – kuegeler.com</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
@@ -12,78 +12,153 @@
   <a href="index.html">Start</a>
 </div>
 <div class="content">
-  <h1>Datenschutz</h1>
-  <p>Webseite https://www.kuegeler.com</p>
-  <h2>Erhebung, Verarbeitung und Nutzung von Daten</h2>
+  <h1>Datenschutzerklärung</h1>
+  <p><em>Stand: 14. August 2026</em></p>
+
   <p>
-  In der Regel können Sie diese Internetseite besuchen, 
-  ohne dass persönliche Daten von Ihnen abgefragt werden. 
-  Bei Bedarf kann der Name Ihres Internet Service Providers, die Webseite, 
-  von der aus sie diese Seite besuchen, und die Webseiten, die Sie auf dieser Seite ansehen, 
-  sowie Datum und Uhrzeit des Besuchs ermittelt werden. Diese Informationen werden ausschließlich zu statistischen Zwecken und zur Verbesserung der Qualität der Internetseiten verwendet. 
-  Besucherdaten bleibt in jedem Fall anonym.
-
-  Persönliche Daten werden nur dann erhoben, wenn Sie diese ausdrücklich und mit vollem Einverständnis mitteilen, 
-  zum Beispiel beim Versand eines E-Mail-Formulars oder beim Abonnement von Benachrichtigungsdiensten. 
-  Diese Webseite nutzt Ihre personenbezogenen Daten ausschließlich zur Beantwortung Ihrer Anfragen. 
-  Zurzeit werden weder Newsletter noch Werbe E-Mails über diese Seite versendet.
-
-  Alle im Rahmen des Zugriffs auf diese Seite anfallenden personenbezogenen Daten werden gemäß 
-  den geltenden Vorschriften zum Schutz personenbezogener Daten grundsätzlich nur zur Wahrung eigener Geschäftsinteressen erhoben, verarbeitet und genutzt. 
-  Ohne ausdrückliche Erlaubnis erfolgt keine Weitergabe dieser Daten an Außenstehende.
+  Diese Erklärung gilt für die älteren, statischen Seiten unter
+  https://www.kuegeler.com (Startseite, Lebenslauf und die Werkseiten).
+  Die Datenschutzerklärung der aktuellen Website finden Sie unter
+  <a href="privacy">https://www.kuegeler.com/privacy</a>.
   </p>
 
- <h2>Links zu externen Seiten und Diensten</h2>
-<p>
-Diese Webseite enthält gegebenenfalls auch Links zu Webseiten externer Dienste, auf die
-sich diese Datenschutzerklärung nicht erstreckt. Der Betreiber dieser Seite hat in der Regel keinen Einfluss auf den Inhalt und die Einhaltung der Datenschutzbestimmungen durch diese Dienste und bittet Sie daher, sich beim Besuch dieser Internetseiten über die dort geltenden Richtlinien zu informieren.
-</p>                        
-<h2>Einsatz von Cookies</h2>
-<p>
-Auf dieser Internetseite werden Cookies eingesetzt, um eine anonyme Auswertung des
-Nutzerverhaltens vornehmen zu können. Auf diese Weise ist es möglich, Ihnen gezielt Informationen zur
-Verfügung zu stellen und das Informationsangebot zu verbessern. Cookies sind kleine Textdateien, die von
-diesem Webserver an Ihren PC verschickt und dort meist auf Ihrer Festplatte abgespeichert
- werden. Sie werden nicht Bestandteil Ihres Systems und können auch keinen Schaden anrichten. Durch den
-Einsatz der Cookies werden keine persönlichen Daten gespeichert oder mit Ihren persönlichen
-Nutzerdaten verbunden. Die meisten Browser sind so eingestellt, dass sie Cookies automatisch
-akzeptieren. Sie können das Speichern von Cookies jedoch deaktivieren oder Ihren Browser so
-einstellen, dass er Sie auf die Sendung eines Cookies hinweist.
-Auf dieser Website kommt Google Analytics zurzeit nicht zum Einsatz. Falls wir in Zukunft Google
-Analytics verwenden sollten dann erfolgt eine entsprechende Anpassung dieser Datenschutzerklärung.
-</p>
-<h2>Widerrufsrecht</h2>
-<p>
-Sie können eine einmal erteilte Einwilligung zur Erhebung, Verarbeitung und Nutzung Ihrer
-personenbezogenen Daten jederzeit mit Wirkung für die Zukunft widerrufen. Ihre Daten werden dann
-gelöscht.
-</p>
-<h2>Auskunftsrecht</h2>
-<p>
-Auf Anforderung teilt der Betreiber dieser Seite Ihnen entsprechend dem geltenden Recht schriftlich mit, ob
-persönlichen Daten über Sie gespeichert sind und um welche Daten es sich dabei konkret handelt.
-</p>
-<h2>Datenschutzbeauftragter</h2>
-  <p>Bei Fragen zum Datenschutz wenden Sie sich bitte via Email an den für diese Seite zuständigen Datenschutzbeauftragten:</p>
-  <p>Michael Kügeler</p>
-  <p>D-80805 München</p>
-  <p>Email: mkuegeler@gmail.com</p>
-  <h2>Referenzen</h2>
-  <h3>Design</h3>
+  <h2>Verantwortlicher</h2>
+  <p>Verantwortlicher im Sinne von Art. 4 Nr. 7 DSGVO ist:</p>
   <p>
-  Das Design der Webseite basiert auf folgender Vorlage: 
+  Michael Kügeler<br>
+  Stengelstr. 2<br>
+  80805 München<br>
+  Deutschland
+  </p>
+  <p>
+  E-Mail: mkuegeler@gmail.com<br>
+  Telefon: +49 89 52032713
+  </p>
+  <p>
+  Ein Datenschutzbeauftragter ist nicht bestellt; die gesetzlichen Voraussetzungen
+  hierfür (Art. 37 DSGVO, § 38 BDSG) liegen nicht vor. Bei Fragen zum Datenschutz
+  wenden Sie sich bitte direkt an die oben genannten Kontaktdaten.
+  </p>
+
+  <h2>Grundsatz</h2>
+  <p>
+  Diese Seiten sind einfache, statische HTML-Seiten. Sie setzen
+  <strong>keine Cookies</strong>, verwenden <strong>keine Analyse- oder
+  Tracking-Dienste</strong> und enthalten <strong>kein Kontaktformular</strong>.
+  Eine anonyme oder personenbezogene Auswertung des Nutzerverhaltens findet nicht
+  statt. Bilder und Videos werden vom eigenen Server ausgeliefert.
+  </p>
+
+  <h2>Hosting und Server-Logfiles</h2>
+  <p>
+  Diese Website wird gehostet bei der IONOS SE, Elgendorfer Straße 57,
+  56410 Montabaur, Deutschland. Die Server stehen in Rechenzentren innerhalb der
+  Europäischen Union. Mit IONOS besteht ein Vertrag über die Verarbeitung im
+  Auftrag gemäß Art. 28 DSGVO.
+  </p>
+  <p>
+  Beim Aufruf dieser Seiten verarbeitet der Hoster automatisch Informationen, die
+  Ihr Browser übermittelt: IP-Adresse, Datum und Uhrzeit des Zugriffs, Name und
+  URL der abgerufenen Datei, übertragene Datenmenge, Referrer-URL sowie Browsertyp,
+  Browserversion und Betriebssystem.
+  </p>
+  <p>
+  <strong>Zweck:</strong> Auslieferung der Website, Systemstabilität und -sicherheit
+  sowie Erkennung und Abwehr von Missbrauch.<br>
+  <strong>Rechtsgrundlage:</strong> Art. 6 Abs. 1 lit. f DSGVO — berechtigtes
+  Interesse am technisch fehlerfreien und sicheren Betrieb dieser Website.<br>
+  <strong>Speicherdauer:</strong> Die Logfiles werden kurzfristig gespeichert und
+  automatisch gelöscht, sofern sie nicht zur Aufklärung eines konkreten
+  Sicherheitsvorfalls benötigt werden. Eine personenbezogene Auswertung erfolgt nicht.
+  </p>
+
+  <h2>Eingebettete Videos von Vimeo</h2>
+  <p>
+  Eine einzelne, nicht verlinkte Archivseite dieses Angebots bindet Videos über den
+  Dienst Vimeo ein (Vimeo.com, Inc., 330 West 34th Street, 5th Floor, New York,
+  New York 10001, USA). Alle übrigen Seiten binden keine fremden Inhalte ein.
+  </p>
+  <p>
+  Beim Aufruf dieser Seite wird eine Verbindung zu den Servern von Vimeo
+  hergestellt. Dabei wird Ihre IP-Adresse an Vimeo übermittelt; Vimeo kann zudem
+  Cookies setzen und Ihr Nutzungsverhalten verarbeiten, gegebenenfalls auch in den
+  USA. Auf Umfang und Zweck dieser Verarbeitung habe ich keinen Einfluss.
+  Einzelheiten entnehmen Sie bitte der Datenschutzerklärung von Vimeo unter
+  https://vimeo.com/privacy.
+  </p>
+  <p>
+  <strong>Rechtsgrundlage:</strong> Art. 6 Abs. 1 lit. f DSGVO. Wenn Sie diese
+  Übermittlung vermeiden möchten, rufen Sie die betreffende Seite bitte nicht auf.
+  </p>
+
+  <h2>Links zu externen Seiten</h2>
+  <p>
+  Diese Seiten enthalten Links zu externen Angeboten. Solange Sie einen solchen Link
+  nicht anklicken, werden keine Daten an den jeweiligen Anbieter übermittelt. Sobald
+  Sie einem Link folgen, verlassen Sie diese Website; für die anschließende
+  Verarbeitung Ihrer Daten ist der jeweilige Anbieter verantwortlich. Bitte
+  informieren Sie sich dort über die geltenden Datenschutzbestimmungen.
+  </p>
+
+  <h2>Kontaktaufnahme per E-Mail</h2>
+  <p>
+  Ein Kontaktformular besteht nicht. Wenn Sie mir eine E-Mail schreiben, verarbeite
+  ich die von Ihnen mitgeteilten Daten ausschließlich zur Bearbeitung Ihres
+  Anliegens. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO beziehungsweise
+  Art. 6 Abs. 1 lit. b DSGVO, sofern Ihre Nachricht auf einen Vertrag gerichtet ist.
+  Ihre Nachricht wird gelöscht, sobald Ihr Anliegen abschließend bearbeitet ist und
+  keine gesetzlichen Aufbewahrungsfristen entgegenstehen. Bitte beachten Sie, dass
+  unverschlüsselte E-Mail nicht gegen unbefugte Kenntnisnahme geschützt ist.
+  </p>
+
+  <h2>Weitergabe von Daten</h2>
+  <p>
+  Über den oben genannten Hoster hinaus gebe ich personenbezogene Daten nicht an
+  Dritte weiter, es sei denn, ich bin gesetzlich dazu verpflichtet. Personenbezogene
+  Daten werden weder verkauft noch vermietet.
+  </p>
+
+  <h2>Ihre Rechte</h2>
+  <p>
+  Sie haben das Recht auf Auskunft (Art. 15 DSGVO), Berichtigung (Art. 16 DSGVO),
+  Löschung (Art. 17 DSGVO), Einschränkung der Verarbeitung (Art. 18 DSGVO),
+  Datenübertragbarkeit (Art. 20 DSGVO) sowie das Recht, einer Verarbeitung auf
+  Grundlage von Art. 6 Abs. 1 lit. f DSGVO zu widersprechen (Art. 21 DSGVO). Eine
+  erteilte Einwilligung können Sie jederzeit mit Wirkung für die Zukunft widerrufen.
+  </p>
+  <p>Zur Ausübung dieser Rechte genügt eine Nachricht an mkuegeler@gmail.com.</p>
+  <p>
+  Unabhängig davon können Sie sich bei einer Datenschutz-Aufsichtsbehörde
+  beschweren, insbesondere bei der Behörde Ihres gewöhnlichen Aufenthaltsorts oder
+  der für mich zuständigen Stelle:
+  </p>
+  <p>
+  Bayerisches Landesamt für Datenschutzaufsicht (BayLDA)<br>
+  Promenade 18<br>
+  91522 Ansbach<br>
+  Deutschland
+  </p>
+
+  <h2>Referenzen</h2>
+  <p>
+  Das Design dieser älteren Seiten basiert auf einer Vorlage von W3Schools:
   https://www.w3schools.com/css/tryit.asp?filename=trycss_template3
   </p>
-  <h3>Speicherorte der Bilder, Videos, Audio und Texte</h3>
-  <p>Video: https://vimeo.com
 </div>
 <div class="footer">
+  <h4>Impressum</h4>
+  <p>Angaben gemäß § 5 DDG</p>
   <p>
-	  <h4>Impressum</h4>
-	  <p>Michael Kügeler</p>
-	  <p>D-80805 München</p>
-      <p>Email: mkuegeler@gmail.com</p> 	  
+  Michael Kügeler<br>
+  Stengelstr. 2<br>
+  80805 München<br>
+  Deutschland
   </p>
+  <p>
+  Email: mkuegeler@gmail.com<br>
+  Telefon: +49 89 52032713
+  </p>
+  <p>Verantwortlich für den Inhalt: Michael Kügeler, Anschrift wie oben.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
The legacy root page contradicted the policy merged in #25 on almost every point.

## What it claimed

- cookies were set to analyse user behaviour
- a section discussing Google Analytics
- a designated *Datenschutzbeauftragter*

None of that is true, and the new policy correctly states the opposite. The page also lacked a postal address, legal bases, retention periods, the hosting provider and the supervisory authority.

## What it says now

Rewritten to mirror `/privacy`, adapted to what the legacy pages actually do: no cookies, no tracking, no contact form, media served from the site's own host, IONOS SE named as processor with EU data centres and an Art. 28 agreement, server log fields with purpose/legal basis/retention, rights under Art. 15–21, and BayLDA as the competent supervisory authority.

The footer now carries provider identification under § 5 DDG with the full address and phone number.

## One difference from the current site, disclosed rather than glossed over

The blanket "no embedded third-party content" wording is correct for the Next.js site but **not** for the legacy pages. `vimeo-090124kgZnghFl-Ym.html` embeds 14 `player.vimeo.com` iframes, so opening it transmits the visitor's IP address to Vimeo in the USA and lets Vimeo set cookies. That page is linked from nowhere, but it is reachable by URL if present on the host, so it gets its own section with its own legal basis rather than being covered by wording that would be untrue.

## Markup

`lang` is `de` rather than `en`, and two structural errors are fixed: an unclosed `<p>` around the references block, and an `<h4>` nested inside a `<p>` in the footer. The page now parses cleanly.

## This does not reach the live site

CI deploys only `michael-kuegeler-blog/out/`, so this file is never uploaded. And because `sftp_upload_direct.sh` runs `mirror -R` without `--delete`, if the legacy site was ever uploaded then the **old** `datenschutz.html` is still on the host, publicly reachable, contradicting the new policy. Editing the repo copy does not change that.

Resolving it needs one of:

- adding the page (and `style.css`) to `michael-kuegeler-blog/public/` so the deploy overwrites the stale copy, or
- deleting the legacy files from the host over SFTP, if that site is considered retired — `cv.html`, `werk/*` and the Vimeo page would be up there too, all carrying the outdated Impressum.

Which applies depends on whether https://www.kuegeler.com/datenschutz.html currently serves the old page; that could not be checked from the build environment, as outbound requests to the site are blocked by the egress proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3Menqxa2JYdkEd6oZwPUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3Menqxa2JYdkEd6oZwPUr)_